### PR TITLE
Piwik BC break

### DIFF
--- a/RerUserDates.php
+++ b/RerUserDates.php
@@ -112,7 +112,7 @@ class RerUserDates extends Plugin
         if (version_compare(Version::VERSION, '2.4.0-b1', 'ge'))
         {
             $settings = new Settings('RerUserDates');
-            $this->profiles = $settings->getSettingValue($settings->profiles);
+            $this->profiles = $settings->getSetting($settings->profiles);
         }
     }
 


### PR DESCRIPTION
Update removed method getSettingValue to getSetting.

Didnt worked anymore in Piwik 2.10 (didnt found the removeage note in changelog...but was still available in 2.7)

Since u use `addSetting` already in https://github.com/RegioneER/RerUserDates/blob/master/Settings.php#L57
it should still work: https://github.com/piwik/piwik/blob/master/core/Plugin/Settings.php#L174-L181

@mattlab can u confirm that?