### PR TITLE
Settings + 2.4 BC break

### DIFF
--- a/API.php
+++ b/API.php
@@ -30,14 +30,9 @@ class API extends \Piwik\Plugin\API
             return false;
         }
 
-        if (version_compare(Version::VERSION, '2.4.0-b1', 'ge'))
-        {
-            $settings = new Settings('RerUserDates');
+        $settings = new Settings('RerUserDates');
 
-            return $settings->getSettingValue($settings->calendars);
-        }
-
-        return false;
+        return $settings->getSetting('profiles')->getValue();
     }
 
     /**

--- a/RerUserDates.php
+++ b/RerUserDates.php
@@ -13,8 +13,6 @@ use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Notification;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
-use Piwik\Url;
-use Piwik\Version;
 
 /**
  */
@@ -109,11 +107,8 @@ class RerUserDates extends Plugin
      */
     protected function checkPiwikSettingsFeature()
     {
-        if (version_compare(Version::VERSION, '2.4.0-b1', 'ge'))
-        {
-            $settings = new Settings('RerUserDates');
-            $this->profiles = $settings->getSetting($settings->profiles);
-        }
+        $settings = new Settings('RerUserDates');
+        $this->profiles = $settings->getSetting('profiles')->getValue();
     }
 
     /**

--- a/Settings.php
+++ b/Settings.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\RerUserDates;
 
 use Piwik\Piwik;
 use Piwik\Settings\SystemSetting;
-use Piwik\Version;
 
 /**
  * Class Settings
@@ -35,11 +34,8 @@ class Settings extends \Piwik\Plugin\Settings
     protected function init()
     {
         $this->setIntroduction(Piwik::translate('RerUserDates_Settings'));
-        if (version_compare(Version::VERSION, '2.4.0-b1', 'ge'))
-        {
-            $this->createProfileSettings();
-            $this->createCalendarSettings();
-        }
+        $this->createProfileSettings();
+        $this->createCalendarSettings();
     }
 
     /**


### PR DESCRIPTION
Badly my last PR contained an issue (my logging didnt worked correctly...):
```
WARNING RerUserDates[2015-02-04 15:45:07] [2471e] D:\htdocs\piwik\core\Plugin\Settings.php(95): Warning - array_key_exists(): The first argument should be either a string or an integer - Piwik 2.10.0 - Please report this message in the Piwik forums: http://forum.piwik.org (please do a search first as it might have been reported already)
```

Additionally i removed the 2.4 BC compability like ref in #7 